### PR TITLE
Add support for request timeout in HTTP calls

### DIFF
--- a/src/main/kotlin/store/kmpd/HttpStorageDeployment.kt
+++ b/src/main/kotlin/store/kmpd/HttpStorageDeployment.kt
@@ -1,11 +1,15 @@
 package store.kmpd
 
 sealed class HttpStorageDeployment {
+
+    abstract val requestTimeoutMillis: Long
+
     class GithubMavenPackage(
         val token: String,
         val username: String,
         val repository: String,
         val packagePath: List<String> = listOf("publication", "files", "all"),
+        override val requestTimeoutMillis: Long = DEFAULT_REQUEST_TIMEOUT_MILLIS,
     ) : HttpStorageDeployment()
 
     class GithubReleases(
@@ -13,11 +17,20 @@ sealed class HttpStorageDeployment {
         val username: String,
         val repository: String,
         val targetCommitish: CommitishSource = CommitishSource.RemoteHEAD(),
+        override val requestTimeoutMillis: Long = DEFAULT_REQUEST_TIMEOUT_MILLIS,
     ) : HttpStorageDeployment()
 
     class Upload(
         val username: String,
         val password: String,
         val uploadDirectoryUrl: String,
+        override val requestTimeoutMillis: Long = DEFAULT_REQUEST_TIMEOUT_MILLIS,
     ) : HttpStorageDeployment()
+
+    companion object {
+        // Default timeout of ktor HTTP client is 15 seconds,
+        // which can be too short for large files and bad network conditions.
+        // see more https://github.com/ktorio/ktor/blob/f8f8fe8a36744fc4b8a5adef79897f2d327743b9/ktor-client/ktor-client-cio/jvmAndNix/src/io/ktor/client/engine/cio/CIOEngineConfig.kt#L37
+        const val DEFAULT_REQUEST_TIMEOUT_MILLIS: Long = 60_000L
+    }
 }

--- a/src/main/kotlin/store/kmpd/deployments/deployFile.kt
+++ b/src/main/kotlin/store/kmpd/deployments/deployFile.kt
@@ -21,6 +21,7 @@ fun deployFile(
                 fileToDeploy = file,
                 deployedFileName = deployedFileName,
                 packagePath = deployment.packagePath,
+                requestTimeoutMillis = deployment.requestTimeoutMillis,
             )
         }
 
@@ -48,6 +49,7 @@ fun deployFile(
                 targetCommitish = targetCommitishString,
                 deployedFileName = deployedFileName,
                 tagName = tagNameProvider(file),
+                requestTimeoutMillis = deployment.requestTimeoutMillis,
             )
         }
 
@@ -58,6 +60,7 @@ fun deployFile(
                 uploadDirectoryUrl = deployment.uploadDirectoryUrl,
                 fileToDeploy = file,
                 deployedFileName = deployedFileName,
+                requestTimeoutMillis = deployment.requestTimeoutMillis,
             )
         }
     }

--- a/src/main/kotlin/store/kmpd/deployments/deployFileToGithubMavenPackages.kt
+++ b/src/main/kotlin/store/kmpd/deployments/deployFileToGithubMavenPackages.kt
@@ -1,6 +1,7 @@
 package store.kmpd.deployments
 
 import io.ktor.client.*
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -17,9 +18,14 @@ fun deployFileToGithubMavenPackages(
     fileToDeploy: File,
     deployedFileName: String,
     packagePath: List<String>,
+    requestTimeoutMillis: Long,
 ): String {
     runBlocking {
-        val client = HttpClient()
+        val client = HttpClient {
+            install(HttpTimeout) {
+                this.requestTimeoutMillis = requestTimeoutMillis
+            }
+        }
         val response = client.put("https://maven.pkg.github.com") {
             url {
                 path(username, repository, *packagePath.toTypedArray(), deployedFileName)

--- a/src/main/kotlin/store/kmpd/deployments/deployFileToGithubReleases.kt
+++ b/src/main/kotlin/store/kmpd/deployments/deployFileToGithubReleases.kt
@@ -1,6 +1,7 @@
 package store.kmpd.deployments
 
 import io.ktor.client.*
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -44,13 +45,18 @@ fun deployFileToGithubReleases(
     fileToDeploy: File,
     deployedFileName: String,
     tagName: String,
+    requestTimeoutMillis: Long,
 ): String {
     runBlocking {
         val json = Json {
             namingStrategy = JsonNamingStrategy.SnakeCase
             ignoreUnknownKeys = true
         }
-        val client = HttpClient()
+        val client = HttpClient {
+            install(HttpTimeout) {
+                this.requestTimeoutMillis = requestTimeoutMillis
+            }
+        }
         val releaseCreationResponse = client.post("https://api.github.com") {
             url {
                 path("repos", username, repository, "releases")

--- a/src/main/kotlin/store/kmpd/deployments/deployFileWithPutToDirectory.kt
+++ b/src/main/kotlin/store/kmpd/deployments/deployFileWithPutToDirectory.kt
@@ -9,6 +9,7 @@ fun deployFileWithPutToDirectory(
     uploadDirectoryUrl: String,
     fileToDeploy: File,
     deployedFileName: String,
+    requestTimeoutMillis: Long,
 ): String {
     val uploadUrl = URLBuilder(uploadDirectoryUrl).appendPathSegments(deployedFileName).build()
     deployWithPut(
@@ -16,6 +17,7 @@ fun deployFileWithPutToDirectory(
         password = password,
         uploadUrl = uploadUrl,
         file = fileToDeploy,
+        requestTimeoutMillis = requestTimeoutMillis,
     )
     return uploadUrl.toString()
 }

--- a/src/main/kotlin/store/kmpd/deployments/deployWithPut.kt
+++ b/src/main/kotlin/store/kmpd/deployments/deployWithPut.kt
@@ -1,6 +1,7 @@
 package store.kmpd.deployments
 
 import io.ktor.client.*
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.*
 import io.ktor.client.plugins.auth.providers.*
 import io.ktor.client.request.*
@@ -17,6 +18,7 @@ fun deployWithPut(
     password: String,
     uploadUrl: Url,
     file: File,
+    requestTimeoutMillis: Long,
 ) {
     runBlocking {
         val client = HttpClient {
@@ -30,6 +32,9 @@ fun deployWithPut(
                         )
                     }
                 }
+            }
+            install(HttpTimeout) {
+                this.requestTimeoutMillis = requestTimeoutMillis
             }
         }
 


### PR DESCRIPTION
## Problem

The library performs HTTP requests using Ktor with a default timeout configuration of 15 seconds. This is not sufficient when dealing with large files and/or slow internet connections, which leads to an error like the following:

```
Execution failed for task ':sdk:deploySdkAsSwiftPackageFromPodPublishDebugXCFramework'.
> io.ktor.client.plugins.HttpRequestTimeoutException: Request timeout has expired [url=https://maven.pkg.github.com/sosafeapp/home-sdk/io.github/sdk-ios/0.1.1748454763/3b63745-1748454942.xcframework.zip, request_timeout=unknown ms]
```

## Solution

Support the requestTimeoutMillis parameter and apply its value to Ktor’s HttpClient.

Usage example:

```
xcframeworkDeployment = SPMXCFrameworkDeployment.HttpDeployment(
    deployment = HttpStorageDeployment.GithubMavenPackage(
        // ...
        requestTimeOutMillis = 300_000 // 5 minutes
    )
)
```